### PR TITLE
[fec] fixed compilation error caused by merge changes related to FEC mode

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2006,7 +2006,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             if (p.m_admin_state_up)
                             {
                                 /* Bring port down before applying fec mode*/
-                                if (!setPortAdminStatus(p, false))
+                                if (!setPortAdminStatus(p.m_port_id, false))
                                 {
                                     SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set fec mode", alias.c_str());
                                     it++;
@@ -2016,7 +2016,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                                 p.m_admin_state_up = false;
                                 p.m_fec_mode = fec_mode_map[fec_mode];
 
-                                if (setPortFec(p, p.m_fec_mode))
+                                if (setPortFec(p.m_port_id, p.m_fec_mode))
                                 {
                                     m_portList[alias] = p;
                                     SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());
@@ -2032,7 +2032,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             {
                                 /* Port is already down, setting fec mode*/
                                 p.m_fec_mode = fec_mode_map[fec_mode];
-                                if (setPortFec(p, p.m_fec_mode))
+                                if (setPortFec(p.m_port_id, p.m_fec_mode))
                                 {
                                     m_portList[alias] = p;
                                     SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());


### PR DESCRIPTION
[fec] fixed compilation error caused by merge changes related to toggling port admin state before applying FEC mode

Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Changed arguments for functions - setPortAdminStatus() and setPortFec()

**Why I did it**

There is a difference between a master and 201911 branches:
Master: functions setPortAdminStatus and setPortFec -  in first argument expect “Port object”
 
      bool PortsOrch::setPortAdminStatus(Port &port, bool state)
      bool PortsOrch::setPortFec(Port &port, sai_port_fec_mode_t mode)
 
201911: functions setPortAdminStatus and setPortFec -  in first argument expect – “sai_object_id_t”
 
      bool PortsOrch::setPortFec(sai_object_id_t id, sai_port_fec_mode_t mode)
      bool PortsOrch::setPortAdminStatus(sai_object_id_t id, bool up)

**How I verified it**

**Details if related**
